### PR TITLE
[Fix] - bug forgot password 

### DIFF
--- a/app/src/main/java/com/example/erabook/fragments/login/LoginFragment.kt
+++ b/app/src/main/java/com/example/erabook/fragments/login/LoginFragment.kt
@@ -118,9 +118,9 @@ class LoginFragment : Fragment() {
             }
           }
         }
-        forgotPasswordTextView.setOnClickListener {
-          startActivity(Intent(requireContext(), ForgotPasswordActivity::class.java))
-        }
+      }
+      forgotPasswordTextView.setOnClickListener {
+        startActivity(Intent(requireContext(), ForgotPasswordActivity::class.java))
       }
     }
   }


### PR DESCRIPTION
the forgot password text wasn't clickable because was within the loginButton parentheses 